### PR TITLE
Websocket threading client ignores initial data send by the server

### DIFF
--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -79,8 +79,11 @@ class WebSocketClient(WebSocketBaseClient):
         try:
             self.sock.setblocking(1)
             while self.running:
-                bytes = self.read_from_connection(next_size)
-                
+                if self.__buffer:
+                    bytes, self.__buffer = self.__buffer[:next_size], self.__buffer[next_size:]
+                else:
+                    bytes = self.read_from_connection(next_size)
+
                 with self._lock:
                     s = self.stream
                     next_size = s.parser.send(bytes)


### PR DESCRIPTION
Fix a bug when data sent by the server immediately after connection is opened is ignored by the client.
