### PR TITLE
support for wss:// connections using ssl.wrap_socket

### DIFF
--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import ssl
 from urlparse import urlsplit
 import socket
 import threading
@@ -43,6 +44,9 @@ class WebSocketClient(WebSocketBaseClient):
         if ':' in host:
             host, port = parts.netloc.split(':')
         self.sock.connect((host, int(port)))
+        
+        if parts.scheme == "wss":
+            self.sock = ssl.wrap_socket(self.sock)
         
         self.write_to_connection(self.handshake_request)
 


### PR DESCRIPTION
Currently ws4py.client.threadedclient does not encrypt traffic to wss:// urls, so I'm unable to write SSL clients.  I added a call to ssl.wrap_socket in these cases, which caused everything to work perfectly for me.  Thanks for making such an awesome library!
