### PR TITLE
send() really shouldn't fail silently when getting an unknown data type

### DIFF
--- a/ws4py/websocket.py
+++ b/ws4py/websocket.py
@@ -180,6 +180,9 @@ class WebSocket(object):
                 first = False
 
             self.sender(message_sender(bytes).fragment(last=True, mask=self.stream.always_mask))
+            
+        else:
+            raise ValueError("Unsupported type '%s' passed to send()" % type(payload))
 
     def _cleanup(self):
         """


### PR DESCRIPTION
I made this edit from the github UI, so you should run it before merging
