### PR TITLE
Delete start()

### DIFF
--- a/ws4py/server/geventserver.py
+++ b/ws4py/server/geventserver.py
@@ -107,7 +107,6 @@ class WebSocketServer(gevent.pywsgi.WSGIServer):
 
     def handler(self, websocket):
         g = gevent.spawn(websocket.run)
-        g.start()
         g.join()
         return ['']
 


### PR DESCRIPTION
Because spawn already has started the greenlet.
