### PR TITLE
Minor fix which turns an unintentional and confusing error message into the intended error message

### DIFF
--- a/ws4py/server/cherrypyserver.py
+++ b/ws4py/server/cherrypyserver.py
@@ -123,7 +123,7 @@ class WebSocketTool(Tool):
 
         for key, expected_value in [('Upgrade', 'websocket'),
                                      ('Connection', 'upgrade')]:
-            actual_value = request.headers.get(key).lower()
+            actual_value = request.headers.get(key, '').lower()
             if not actual_value:
                 raise HandshakeError('Header %s is not defined' % key)
             if expected_value not in actual_value:


### PR DESCRIPTION
WebSocketTool.upgrade is supposed to raise a HandshakeError with the message "Header %s is not defined" if either the "Upgrade" or "Connection" header is missing.

However, the expression on line 126 of cherrypyserver.py:

request.headers.get(key).lower()

raises an AttributeError with the message "'NoneType' object has no attribute 'lower'" if one of those headers is missing, which prevents the intended error message from ever being displayed.

This commit fixes this problem by replacing get(key) with get(key, '') since the empty string evaluates as false.
