### PR TITLE
Bug fix in WebSocketPlugin.broadcast()

### DIFF
--- a/ws4py/server/cherrypyserver.py
+++ b/ws4py/server/cherrypyserver.py
@@ -339,7 +339,7 @@ class WebSocketPlugin(plugins.SimplePlugin):
         """
         for ws_handler in self.pool:
             try:
-                ws_handler.send(message, message.is_binary)
+                ws_handler.send(message, binary)
             except:
                 cherrypy.log(traceback=True)
             


### PR DESCRIPTION
Hi Sylvain,

I think I found a small bug in WebSocketPlugin.broadcast() concerning the 'binary' parameter passed to the send method. Could you confirm this, and possibly integrate that fix to your repository? 

ciao ciao

Ralph
