### PR TITLE
Don't discard query string when building GET URL.

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -97,7 +97,10 @@ class WebSocketBaseClient(WebSocket):
         parts = urlsplit(self.url)
         
         headers = self.handshake_headers
-        request = ["GET %s HTTP/1.1" % parts.path]
+        if parts.query:
+            request = ["GET %s?%s HTTP/1.1" % (parts.path, parts.query)]
+        else:
+            request = ["GET %s HTTP/1.1" % parts.path]
         for header, value in headers:
             request.append("%s: %s" % (header, value))
         request.append('\r\n')


### PR DESCRIPTION
This is a small patch so that the query string on a URL is not discarded when creating a WebSocket client.  With this patch, you can do something like:

``` python
    ws = WebSocketClient("http://example.com/foobar?x=y&a=b")
```

This can be useful for setting initial arguments for the WebSocket connection.
