### PR TITLE
Don't broadcast messages to terminated WebSockets

### DIFF
--- a/ws4py/server/cherrypyserver.py
+++ b/ws4py/server/cherrypyserver.py
@@ -346,7 +346,8 @@ class WebSocketPlugin(plugins.SimplePlugin):
         """
         for ws_handler in self.pool:
             try:
-                ws_handler.send(message, binary)
+                if not ws_handler.terminated:
+                    ws_handler.send(message, binary)
             except:
                 cherrypy.log(traceback=True)
             


### PR DESCRIPTION
If a message is broadcasted through the CherryPy bus in the time interval
between a WebSocket is closed and it is cleaned out of WebSocketPlugin.pool, it
will cause and error in WebSocket.send:

``` python
Traceback (most recent call last):
  File ".../ws4py/server/cherrypyserver.py", line 349, in broadcast
    ws_handler.send(message, binary)
  File ".../ws4py/websocket.py", line 167, in send
    message_sender = self.stream.binary_message if binary else
self.stream.text_message
AttributeError: 'NoneType' object has no attribute 'text_message'
```

This patch checks if each WebSocket handler is terminated or not before trying
to send the broadcasted message, avoiding the above error.
