### PR TITLE
bytearray cannot pass the Tornado's bytes_type assertion

### DIFF
--- a/ws4py/framing.py
+++ b/ws4py/framing.py
@@ -116,10 +116,9 @@ class Frame(object):
         ## + - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
         ## |                     Payload Data continued ...                |
         ## +---------------------------------------------------------------+
-        if not self.masking_key:
-            return header + enc(self.body)
-
-        return header + self.masking_key + self.mask(enc(self.body))
+        if self.masking_key:
+            header += pack('!BBBB', *map(ord, self.masking_key))
+        return header + pack('!' + 'B' * self.payload_length, *self.mask(enc(self.body)))
 
     def _parsing(self):
         """


### PR DESCRIPTION
``` python
File "/home/wenhao/workspace/python/WebSocket-for-Python/ws4py/websocket.py", line 175, in send
    self.sender(m)
  File "/usr/local/lib/python2.7/dist-packages/tornado/iostream.py", line 203, in write
    assert isinstance(data, bytes_type)
```

Change the Frame.build to return a string instead.
