### PR TITLE
select.select() on Windows does not allow empty rlist.

### DIFF
--- a/ws4py/manager.py
+++ b/ws4py/manager.py
@@ -89,7 +89,7 @@ class SelectPoller(object):
         Polls once and returns a list of
         ready-to-be-read file descriptors.
         """
-        if len(self._fds) == 0:
+        if not self._fds:
             return []
 
         r, w, x = select.select(self._fds, [], [], self.timeout)


### PR DESCRIPTION
...be

empty.  I added a simple check for this case and return the corresponding
empty results list to the caller.

See Python docs for details: http://docs.python.org/2/library/select.html#select.select
