### PR TITLE
Code correction in built-in client tutorial

### DIFF
--- a/docs/sources/clienttutorial.rst
+++ b/docs/sources/clienttutorial.rst
@@ -40,7 +40,7 @@ until the websocket is closed.
         try:
             ws = DummyClient('ws://localhost:9000/', protocols=['http-only', 'chat'])
             ws.connect()
-	    ws.join()
+            ws.run_forever()
         except KeyboardInterrupt:
             ws.close()
 


### PR DESCRIPTION
The call to `ws.join()` in the built-in client tutorial seems to be out of date with the implementation. From the source it appears that `ws.run_forever()` is the correct call.
