### PR TITLE
ws4py.client classes should support client certificates

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -13,7 +13,7 @@ from ws4py.compat import urlsplit, enc, dec
 __all__ = ['WebSocketBaseClient']
 
 class WebSocketBaseClient(WebSocket):
-    def __init__(self, url, protocols=None, extensions=None, heartbeat_freq=None):
+    def __init__(self, url, protocols=None, extensions=None, heartbeat_freq=None, ssl_options=None):
         """
         A websocket client that implements :rfc:`6455` and provides a simple
         interface to communicate with a websocket server.
@@ -37,6 +37,7 @@ class WebSocketBaseClient(WebSocket):
         self.scheme = None
         self.port = None
         self.resource = None
+        self.ssl_options = ssl_options or {}
 
         self._parse_url()
 
@@ -128,7 +129,7 @@ class WebSocketBaseClient(WebSocket):
         """
         if self.scheme == "wss":
             # default port is now 443; upgrade self.sender to send ssl
-            self.sock = ssl.wrap_socket(self.sock)
+            self.sock = ssl.wrap_socket(self.sock, **self.ssl_options)
 
         self.sock.connect((self.host, self.port))
 

--- a/ws4py/client/geventclient.py
+++ b/ws4py/client/geventclient.py
@@ -10,7 +10,7 @@ from ws4py.client import WebSocketBaseClient
 __all__ = ['WebSocketClient']
 
 class WebSocketClient(WebSocketBaseClient):
-    def __init__(self, url, protocols=None, extensions=None):
+    def __init__(self, url, protocols=None, extensions=None, ssl_options=None):
         """
         WebSocket client that executes the
         :meth:`run() <ws4py.websocket.WebSocket.run>` into a gevent greenlet.
@@ -40,7 +40,7 @@ class WebSocketClient(WebSocketBaseClient):
           ]
           gevent.joinall(greenlets)
         """
-        WebSocketBaseClient.__init__(self, url, protocols, extensions)
+        WebSocketBaseClient.__init__(self, url, protocols, extensions, ssl_options=ssl_options)
         self._th = Greenlet(self.run)
 
         self.messages = Queue()

--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -6,7 +6,7 @@ from ws4py.client import WebSocketBaseClient
 __all__ = ['WebSocketClient']
 
 class WebSocketClient(WebSocketBaseClient):
-    def __init__(self, url, protocols=None, extensions=None, heartbeat_freq=None):
+    def __init__(self, url, protocols=None, extensions=None, heartbeat_freq=None, ssl_options=None):
         """
         .. code-block:: python
 
@@ -30,7 +30,7 @@ class WebSocketClient(WebSocketBaseClient):
               ws.close()
 
         """
-        WebSocketBaseClient.__init__(self, url, protocols, extensions, heartbeat_freq)
+        WebSocketBaseClient.__init__(self, url, protocols, extensions, heartbeat_freq, ssl_options)
         self._th = threading.Thread(target=self.run, name='WebSocketClient')
         self._th.daemon = True
 

--- a/ws4py/client/tornadoclient.py
+++ b/ws4py/client/tornadoclient.py
@@ -8,7 +8,7 @@ from ws4py.exc import HandshakeError
 __all__ = ['TornadoWebSocketClient']
 
 class TornadoWebSocketClient(WebSocketBaseClient):
-    def __init__(self, url, protocols=None, extensions=None, io_loop=None):
+    def __init__(self, url, protocols=None, extensions=None, io_loop=None, ssl_options=None):
         """
         .. code-block:: python
 
@@ -30,10 +30,10 @@ class TornadoWebSocketClient(WebSocketBaseClient):
 
             ioloop.IOLoop.instance().start()
         """
-        WebSocketBaseClient.__init__(self, url, protocols, extensions)
+        WebSocketBaseClient.__init__(self, url, protocols, extensions, ssl_options=ssl_options)
+        self.ssl_options["do_handshake_on_connect"] = False
         if self.scheme == "wss":
-            self.sock = ssl.wrap_socket(self.sock,
-                    do_handshake_on_connect=False)
+            self.sock = ssl.wrap_socket(self.sock, **self.ssl_options)
             self.io = iostream.SSLIOStream(self.sock, io_loop)
         else:
             self.io = iostream.IOStream(self.sock, io_loop)


### PR DESCRIPTION
My company uses websockets to write rich Javascript applications, but we also use websockets as the transport mechanism for a homegrown RPC protocol to let backend software subscribe to topics and get notifications when new data is available (a classic pub/sub scenario).

We use client certificates for authentication, but ws4py doesn't support client certificates.  I've added a new argument to __init__ for the client classes which is a dictionary of options that will be passed to ssl.wrap_socket(), which allows us to specify client certs.

We've tested this code on our local network (as well as run the ws4py unit tests) and confirmed that we can connect to our client-cert-protected nginx server and it works great, so I'm hoping this will get merged into the main ws4py project so that we don't have to maintain our own patched version.

Please let me know if there's anything else I can do to make this pull request more suitable for inclusion.
