### PR TITLE
fix: changed gevent server to use a real gevent.pool.Pool

### DIFF
--- a/ws4py/server/geventserver.py
+++ b/ws4py/server/geventserver.py
@@ -20,7 +20,7 @@ import sys
 
 import gevent
 from gevent.pywsgi import WSGIHandler, WSGIServer as _WSGIServer
-from gevent.pool import Group
+from gevent.pool import Pool
 
 from ws4py import format_addresses
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
@@ -61,7 +61,7 @@ class WebSocketWSGIHandler(WSGIHandler):
         else:
             gevent.pywsgi.WSGIHandler.run_application(self)
 
-class GEventWebSocketPool(Group):
+class GEventWebSocketPool(Pool):
     """
     Simple pool of bound websockets.
     Internally it uses a gevent group to track


### PR DESCRIPTION
The gevent StreamServer requires the pool to really be a gevent.pool.Pool, else the stop() method fails with an AttributeError exception.

What I got before the fix:
Exception in thread Thread-3:
Traceback (most recent call last):
  File "C:\Program Files (x86)\Python\lib\threading.py", line 808, in __bootstrap_inner
    self.run()
  File "C:\Program Files (x86)\Python\lib\threading.py", line 761, in run
    self.__target(_self.__args, *_self.__kwargs)
  File "[...].py", line 145, in timeout
    self.server.stop()
  File "E:\Informatik\Python\WebSocket-for-Python\ws4py\server\geventserver.py", line 107, in stop
    _WSGIServer.stop(self, _args, *_kwargs)
  File "C:\Program Files (x86)\Python\lib\site-packages\gevent\baseserver.py", line 173, in stop
    self.kill()
  File "C:\Program Files (x86)\Python\lib\site-packages\gevent\server.py", line 87, in kill
    pool._semaphore.unlink(self._start_accepting_if_started)
AttributeError: 'GEventWebSocketPool' object has no attribute '_semaphore'
