### PR TITLE
Don't fail when websocket was not inited.

### DIFF
--- a/ws4py/server/geventserver.py
+++ b/ws4py/server/geventserver.py
@@ -55,7 +55,7 @@ class WebSocketWSGIHandler(WSGIHandler):
                 self.socket = None
                 self.rfile.close()
 
-                ws = self.environ.pop('ws4py.websocket')
+                ws = self.environ.pop('ws4py.websocket', None)
                 if ws:
                     self.server.pool.track(ws)
         else:


### PR DESCRIPTION
Don't fail in geventserver when a WSGI application returns a response without having created  a websocket.
