### PR TITLE
pass ssl_options to SSLIOStream() to ensure certificate validation works

### DIFF
--- a/ws4py/client/tornadoclient.py
+++ b/ws4py/client/tornadoclient.py
@@ -33,10 +33,9 @@ class TornadoWebSocketClient(WebSocketBaseClient):
         """
         WebSocketBaseClient.__init__(self, url, protocols, extensions,
                                      ssl_options=ssl_options, headers=headers)
-        self.ssl_options["do_handshake_on_connect"] = False
         if self.scheme == "wss":
-            self.sock = ssl.wrap_socket(self.sock, **self.ssl_options)
-            self.io = iostream.SSLIOStream(self.sock, io_loop)
+            self.sock = ssl.wrap_socket(self.sock, do_handshake_on_connect=False, **self.ssl_options)
+            self.io = iostream.SSLIOStream(self.sock, io_loop, ssl_options=self.ssl_options)
         else:
             self.io = iostream.IOStream(self.sock, io_loop)
         self.io_loop = io_loop


### PR DESCRIPTION
The Tornado client's **init** function uses an SSLIOStream object for SSL communications when using a wss: scheme. The **init** function for that object will use the optional ssl_options parameter to set parameters used for certificate verification. This change passes the ssl_options (already present in TornadoWebSocketClient.**init**()) to the SSLIOStream object.
