### PR TITLE
Improve Origin handling in Client

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -266,10 +266,10 @@ class WebSocketBaseClient(WebSocket):
                 self.host = parsed.hostname
             else:
                 self.host = 'localhost'
-            url = scheme + '://' + parsed.hostname
+            origin = scheme + '://' + parsed.hostname
             if parsed.port:
-                url = url + ':' + str(parsed.port)
-            headers.append(('Origin', url))
+                origin = origin + ':' + str(parsed.port)
+            headers.append(('Origin', origin))
 
         return headers
 


### PR DESCRIPTION
This change makes the Origin comply with rfc 6454, in that it is now scheme://hostname[:port], in lieu of full url.  

Also allows overriding of default Origin with an Origin header in the headers parameter to constructor.

Thank you.
