### PR TITLE
PEP8 plus optimizations.

### DIFF
--- a/test/test_frame.py
+++ b/test/test_frame.py
@@ -4,15 +4,16 @@ import unittest
 import types
 import random
 
-from ws4py.framing import Frame, \
-     OPCODE_CONTINUATION, OPCODE_TEXT, \
-     OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG
+from ws4py.framing import (
+    Frame, OPCODE_CONTINUATION, OPCODE_TEXT, OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG)
 from ws4py.exc import FrameTooLargeException, ProtocolException
 from ws4py.compat import *
+
 
 def map_on_bytes(f, bytes):
     for index, byte in enumerate(bytes):
         f(bytes[index:index+1])
+
 
 class WSFrameBuilderTest(unittest.TestCase):
     def test_7_bit_length(self):
@@ -101,6 +102,7 @@ class WSFrameBuilderTest(unittest.TestCase):
 
     def test_passing_unencoded_string_raises_type_error(self):
         self.assertRaises(TypeError, Frame, opcode=OPCODE_TEXT, body=u'\xe9', fin=1)
+
 
 class WSFrameParserTest(unittest.TestCase):
     def test_frame_parser_is_a_generator(self):
@@ -271,7 +273,8 @@ class WSFrameParserTest(unittest.TestCase):
         # parse the rest of our data
         f.parser.send(bytes[10:])
         self.assertEqual(f.body, body)
-        
+
+
 if __name__ == '__main__':
     suite = unittest.TestSuite()
     loader = unittest.TestLoader()

--- a/ws4py/__init__.py
+++ b/ws4py/__init__.py
@@ -26,15 +26,16 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-import logging
-import logging.handlers as handlers
+import logging.handlers
+
 
 __author__ = "Sylvain Hellegouarch"
 __version__ = "0.3.5"
-__all__ = ['WS_KEY', 'WS_VERSION', 'configure_logger', 'format_addresses']
+__all__ = ['WS_KEY', 'WS_VERSION', 'configure_logger']
 
 WS_KEY = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 WS_VERSION = (8, 13)
+
 
 def configure_logger(stdout=True, filepath=None, level=logging.INFO):
     logger = logging.getLogger('ws4py')
@@ -42,7 +43,7 @@ def configure_logger(stdout=True, filepath=None, level=logging.INFO):
     logfmt = logging.Formatter("[%(asctime)s] %(levelname)s %(message)s")
 
     if filepath:
-        h = handlers.RotatingFileHandler(filepath, maxBytes=10485760, backupCount=3)
+        h = logging.handlers.RotatingFileHandler(filepath, maxBytes=10485760, backupCount=3)
         h.setLevel(level)
         h.setFormatter(logfmt)
         logger.addHandler(h)
@@ -55,13 +56,3 @@ def configure_logger(stdout=True, filepath=None, level=logging.INFO):
         logger.addHandler(h)
 
     return logger
-
-def format_addresses(ws):
-    me = ws.local_address
-    peer = ws.peer_address
-    if isinstance(me, tuple) and isinstance(peer, tuple):
-        me_ip, me_port = ws.local_address
-        peer_ip, peer_port = ws.peer_address
-        return "[Local => %s:%d | Remote => %s:%d]" % (me_ip, me_port, peer_ip, peer_port)
-
-    return "[Bound to '%s']" % me

--- a/ws4py/manager.py
+++ b/ws4py/manager.py
@@ -46,10 +46,10 @@ import select
 import threading
 import time
 
-from ws4py import format_addresses
 from ws4py.compat import py3k
 
 logger = logging.getLogger('ws4py')
+
 
 class SelectPoller(object):
     def __init__(self, timeout=0.1):
@@ -96,6 +96,7 @@ class SelectPoller(object):
         r, w, x = select.select(self._fds, [], [], self.timeout)
         return r
 
+
 class EPollPoller(object):
     def __init__(self, timeout=0.1):
         """
@@ -140,6 +141,7 @@ class EPollPoller(object):
             if event | select.EPOLLIN | select.EPOLLPRI:
                 yield fd
 
+
 class KQueuePoller(object):
     def __init__(self, timeout=0.1):
         """
@@ -183,6 +185,7 @@ class KQueuePoller(object):
         for fd, event in events:
             if event | select.EPOLLIN | select.EPOLLPRI:
                 yield fd
+
 
 class WebSocketManager(threading.Thread):
     def __init__(self, poller=None):
@@ -240,7 +243,7 @@ class WebSocketManager(threading.Thread):
         if websocket in self:
             return
         
-        logger.info("Managing websocket %s" % format_addresses(websocket))
+        logger.info("Managing websocket %s", websocket)
         websocket.opened()
         with self.lock:
             fd = websocket.sock.fileno()
@@ -258,7 +261,7 @@ class WebSocketManager(threading.Thread):
         if websocket not in self:
             return
         
-        logger.info("Removing websocket %s" % format_addresses(websocket))
+        logger.info("Removing websocket %s", websocket)
         with self.lock:
             fd = websocket.sock.fileno()
             self.websockets.pop(fd, None)
@@ -314,7 +317,7 @@ class WebSocketManager(threading.Thread):
                             self.poller.unregister(fd)
 
                         if not ws.terminated:
-                            logger.info("Terminating websocket %s" % format_addresses(ws))
+                            logger.info("Terminating websocket %s", ws)
                             ws.terminate()
 
     def close_all(self, code=1001, message='Server is shutting down'):
@@ -324,7 +327,7 @@ class WebSocketManager(threading.Thread):
         It doesn't wait for the handshake to complete properly.
         """
         with self.lock:
-            logger.info("Closing all websockets with [%d] '%s'" % (code, message))
+            logger.info("Closing all websockets with [%d] '%s'", code, message)
             for ws in iter(self):
                 ws.close(code=code, reason=message)
 

--- a/ws4py/messaging.py
+++ b/ws4py/messaging.py
@@ -6,8 +6,10 @@ from ws4py.framing import Frame, OPCODE_CONTINUATION, OPCODE_TEXT, \
      OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG
 from ws4py.compat import unicode, py3k
 
+
 __all__ = ['Message', 'TextMessage', 'BinaryMessage', 'CloseControlMessage',
            'PingControlMessage', 'PongControlMessage']
+
 
 class Message(object):
     def __init__(self, opcode, data=b'', encoding='utf-8'):
@@ -111,6 +113,7 @@ class Message(object):
     def __unicode__(self):
         return self.data.decode(self.encoding)
 
+
 class TextMessage(Message):
     def __init__(self, text=None):
         Message.__init__(self, OPCODE_TEXT, text)
@@ -122,6 +125,7 @@ class TextMessage(Message):
     @property
     def is_text(self):
         return True
+
 
 class BinaryMessage(Message):
     def __init__(self, bytes=None):
@@ -137,6 +141,7 @@ class BinaryMessage(Message):
 
     def __len__(self):
         return len(self.data)
+
 
 class CloseControlMessage(Message):
     def __init__(self, code=1000, reason=''):
@@ -160,9 +165,11 @@ class CloseControlMessage(Message):
     def __unicode__(self):
         return self.reason.decode(self.encoding)
 
+
 class PingControlMessage(Message):
     def __init__(self, data=None):
         Message.__init__(self, OPCODE_PING, data)
+
 
 class PongControlMessage(Message):
     def __init__(self, data):

--- a/ws4py/server/wsgirefserver.py
+++ b/ws4py/server/wsgirefserver.py
@@ -26,7 +26,6 @@ workflow.
    For some reason this server may fail against autobahntestsuite.
 """
 import logging
-import sys
 from wsgiref.handlers import SimpleHandler
 from wsgiref.simple_server import WSGIRequestHandler, WSGIServer as _WSGIServer
 from wsgiref import util
@@ -34,14 +33,15 @@ from wsgiref import util
 util._hoppish = {}.__contains__
 
 from ws4py.manager import WebSocketManager
-from ws4py import format_addresses
 from ws4py.server.wsgiutils import WebSocketWSGIApplication
 from ws4py.compat import get_connection
+
 
 __all__ = ['WebSocketWSGIHandler', 'WebSocketWSGIRequestHandler',
            'WSGIServer']
 
 logger = logging.getLogger('ws4py')
+
 
 class WebSocketWSGIHandler(SimpleHandler):
     def setup_environ(self):
@@ -78,6 +78,7 @@ class WebSocketWSGIHandler(SimpleHandler):
             if ws:
                 self.request_handler.server.link_websocket_to_server(ws)
 
+
 class WebSocketWSGIRequestHandler(WSGIRequestHandler):
     def handle(self):
         """
@@ -94,6 +95,7 @@ class WebSocketWSGIRequestHandler(WSGIRequestHandler):
         )
         handler.request_handler = self      # backpointer for logging
         handler.run(self.server.get_app())
+
 
 class WSGIServer(_WSGIServer):
     def initialize_websockets_manager(self):
@@ -130,6 +132,7 @@ class WSGIServer(_WSGIServer):
             self.manager.join()
             delattr(self, 'manager')
         _WSGIServer.server_close(self)
+
 
 if __name__ == '__main__':
     from ws4py import configure_logger

--- a/ws4py/streaming.py
+++ b/ws4py/streaming.py
@@ -2,16 +2,17 @@
 import struct
 from struct import unpack
 
-from ws4py.utf8validator import Utf8Validator
-from ws4py.messaging import TextMessage, BinaryMessage, CloseControlMessage,\
-     PingControlMessage, PongControlMessage
-from ws4py.framing import Frame, OPCODE_CONTINUATION, OPCODE_TEXT, \
-     OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG
-from ws4py.exc import FrameTooLargeException, ProtocolException, InvalidBytesError,\
-     TextFrameEncodingException, UnsupportedFrameTypeException, StreamClosed
-from ws4py.compat import py3k
+from .utf8validator import Utf8Validator
+from .messaging import (
+    TextMessage, BinaryMessage, CloseControlMessage, PingControlMessage, PongControlMessage)
+from .framing import (
+    Frame, OPCODE_CONTINUATION, OPCODE_TEXT, OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG)
+from .exc import FrameTooLargeException, ProtocolException
+from .compat import py3k
+
 
 VALID_CLOSING_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011]
+
 
 class Stream(object):
     def __init__(self, always_mask=False, expect_masking=True):

--- a/ws4py/utils.py
+++ b/ws4py/utils.py
@@ -1,0 +1,51 @@
+class _Missing(object):
+
+    def __repr__(self):
+        return 'no value'
+
+    def __reduce__(self):
+        return '_missing'
+
+_missing = _Missing()
+
+
+# copied from werkzeug.utils.cached_property
+class cached_property(object):
+    """A decorator that converts a function into a lazy property.  The
+    function wrapped is called the first time to retrieve the result
+    and then that calculated result is used the next time you access
+    the value::
+
+        class Foo(object):
+
+            @cached_property
+            def foo(self):
+                # calculate something important here
+                return 42
+
+    The class has to have a `__dict__` in order for this property to
+    work.
+    """
+
+    # implementation detail: this property is implemented as non-data
+    # descriptor.  non-data descriptors are only invoked if there is
+    # no entry with the same name in the instance's __dict__.
+    # this allows us to completely get rid of the access function call
+    # overhead.  If one choses to invoke __get__ by hand the property
+    # will still work as expected because the lookup logic is replicated
+    # in __get__ for manual invocation.
+
+    def __init__(self, func, name=None, doc=None):
+        self.__name__ = name or func.__name__
+        self.__module__ = func.__module__
+        self.__doc__ = doc or func.__doc__
+        self.func = func
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        value = obj.__dict__.get(self.__name__, _missing)
+        if value is _missing:
+            value = self.func(obj)
+            obj.__dict__[self.__name__] = value
+        return value


### PR DESCRIPTION
I've built a websocket server based on gevent-websocket and another one using ws4py. The server based on ws4py is quite slow compared to gevent-websocket, so I looked trough ws4py code to see what can be optimized. 

I guess one of the reasons is that ws4py targets python 3 too having additional code paths. 

The main reason for performance difference should be some architectural decisions, but I am not that good to fix it.
