### PR TITLE
Fix except syntax for Python 3 in test_manager.py

### DIFF
--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -181,7 +181,7 @@ class WSSelectPollerTest(unittest.TestCase):
         poller.unregister(0)
         try:
             poller.unregister(0)
-        except Exception, ex:
+        except Exception as ex:
             self.fail("Shouldn't have failed: %s" % ex)
             
      
@@ -267,7 +267,7 @@ class WSEPollPollerTest(unittest.TestCase):
         poller.unregister(0)
         try:
             poller.unregister(0)
-        except Exception, ex:
+        except Exception as ex:
             self.fail("Shouldn't have failed: %s" % ex)
             
 if __name__ == '__main__':


### PR DESCRIPTION
This also works for Python 2.6+.