### PR TITLE
Retry `self.sock.recv(self.reading_buffer_size)` if we receive EINTR.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-import os, os.path
-from glob import iglob
-import sys
+from sys import version_info
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 from distutils.command.build_py import build_py
+
 
 class buildfor2or3(build_py):
     def find_package_modules(self, package, package_dir):
@@ -22,41 +21,42 @@ class buildfor2or3(build_py):
         modules = build_py.find_package_modules(self, package, package_dir)
         amended_modules = []
         for (package_, module, module_file) in modules:
-            if sys.version_info < (3,):
+            if version_info < (3,):
                 if module in ['async_websocket', 'tulipserver']:
                     continue
             amended_modules.append((package_, module, module_file))
         return amended_modules
-  
-setup(name = "ws4py",
-      version = '0.3.5',
-      description = "WebSocket client and server library for Python 2 and 3 as well as PyPy",
-      maintainer = "Sylvain Hellegouarch",
-      maintainer_email = "sh@defuze.org",
-      url = "https://github.com/Lawouach/WebSocket-for-Python",
-      download_url = "https://pypi.python.org/pypi/ws4py",
-      packages = ['ws4py', 'ws4py.client', 'ws4py.server'],
-      platforms = ["any"],
-      license = 'BSD',
-      long_description = "WebSocket client and server library for Python 2 and 3 as well as PyPy",
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Framework :: CherryPy',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: BSD License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
-          'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Programming Language :: Python :: Implementation :: PyPy',
-          'Topic :: Communications',
-          'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
-          'Topic :: Internet :: WWW/HTTP :: WSGI :: Server',
-          'Topic :: Software Development :: Libraries :: Python Modules'
-      ],
-      cmdclass=dict(build_py=buildfor2or3)
-     )
+
+setup(
+    name="ws4py",
+    version='0.3.5',
+    description="WebSocket client and server library for Python 2 and 3 as well as PyPy",
+    maintainer="Sylvain Hellegouarch",
+    maintainer_email="sh@defuze.org",
+    url="https://github.com/Lawouach/WebSocket-for-Python",
+    download_url="https://pypi.python.org/pypi/ws4py",
+    packages=['ws4py', 'ws4py.client', 'ws4py.server'],
+    platforms=["any"],
+    license='BSD',
+    long_description="WebSocket client and server library for Python 2 and 3 as well as PyPy",
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Framework :: CherryPy',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+        'Topic :: Communications',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Server',
+        'Topic :: Software Development :: Libraries :: Python Modules'
+    ],
+    cmdclass=dict(build_py=buildfor2or3)
+)

--- a/ws4py/__init__.py
+++ b/ws4py/__init__.py
@@ -36,6 +36,7 @@ __all__ = ['WS_KEY', 'WS_VERSION', 'configure_logger', 'format_addresses']
 WS_KEY = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 WS_VERSION = (8, 13)
 
+
 def configure_logger(stdout=True, filepath=None, level=logging.INFO):
     logger = logging.getLogger('ws4py')
     logger.setLevel(level)
@@ -55,6 +56,7 @@ def configure_logger(stdout=True, filepath=None, level=logging.INFO):
         logger.addHandler(h)
 
     return logger
+
 
 def format_addresses(ws):
     me = ws.local_address

--- a/ws4py/async_websocket.py
+++ b/ws4py/async_websocket.py
@@ -23,6 +23,7 @@ from ws4py.messaging import Message
 
 __all__ = ['WebSocket', 'EchoWebSocket']
 
+
 class WebSocket(_WebSocket):
     def __init__(self, proto):
         """
@@ -116,6 +117,7 @@ class WebSocket(_WebSocket):
             self.terminate()
 
         return True
+
 
 class EchoWebSocket(WebSocket):
     def received_message(self, message):

--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -12,6 +12,7 @@ from ws4py.compat import urlsplit
 
 __all__ = ['WebSocketBaseClient']
 
+
 class WebSocketBaseClient(WebSocket):
     def __init__(self, url, protocols=None, extensions=None,
                  heartbeat_freq=None, ssl_options=None, headers=None):
@@ -87,10 +88,14 @@ class WebSocketBaseClient(WebSocket):
             # Let's handle IPv4 and IPv6 addresses
             # Simplified from CherryPy's code
             try:
-                family, socktype, proto, canonname, sa = socket.getaddrinfo(self.host, self.port,
-                                                                            socket.AF_UNSPEC,
-                                                                            socket.SOCK_STREAM,
-                                                                            0, socket.AI_PASSIVE)[0]
+                family, socktype, proto, canonname, sa = socket.getaddrinfo(
+                    self.host,
+                    self.port,
+                    socket.AF_UNSPEC,
+                    socket.SOCK_STREAM,
+                    0,
+                    socket.AI_PASSIVE
+                )[0]
             except socket.gaierror:
                 family = socket.AF_INET
                 if self.host.startswith('::'):
@@ -104,8 +109,11 @@ class WebSocketBaseClient(WebSocket):
             sock = socket.socket(family, socktype, proto)
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            if hasattr(socket, 'AF_INET6') and family == socket.AF_INET6 and \
-              self.host.startswith('::'):
+            if (
+                hasattr(socket, 'AF_INET6') and
+                family == socket.AF_INET6 and
+                self.host.startswith('::')
+               ):
                 try:
                     sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
                 except (AttributeError, socket.error):
@@ -206,7 +214,7 @@ class WebSocketBaseClient(WebSocket):
             # default port is now 443; upgrade self.sender to send ssl
             self.sock = ssl.wrap_socket(self.sock, **self.ssl_options)
             self._is_secure = True
-            
+
         self.sock.connect(self.bind_addr)
 
         self._write(self.handshake_request)
@@ -252,7 +260,7 @@ class WebSocketBaseClient(WebSocket):
             ('Sec-WebSocket-Key', self.key.decode('utf-8')),
             ('Sec-WebSocket-Version', str(max(WS_VERSION)))
             ]
-        
+
         if self.protocols:
             headers.append(('Sec-WebSocket-Protocol', ','.join(self.protocols)))
 

--- a/ws4py/client/geventclient.py
+++ b/ws4py/client/geventclient.py
@@ -9,6 +9,7 @@ from ws4py.client import WebSocketBaseClient
 
 __all__ = ['WebSocketClient']
 
+
 class WebSocketClient(WebSocketBaseClient):
     def __init__(self, url, protocols=None, extensions=None, ssl_options=None, headers=None):
         """

--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -5,6 +5,7 @@ from ws4py.client import WebSocketBaseClient
 
 __all__ = ['WebSocketClient']
 
+
 class WebSocketClient(WebSocketBaseClient):
     def __init__(self, url, protocols=None, extensions=None, heartbeat_freq=None,
                  ssl_options=None, headers=None):

--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import threading
+import signal
 
 from ws4py.client import WebSocketBaseClient
 
@@ -36,6 +37,11 @@ class WebSocketClient(WebSocketBaseClient):
                                      ssl_options, headers=headers)
         self._th = threading.Thread(target=self.run, name='WebSocketClient')
         self._th.daemon = True
+
+    def run(self):
+        if hasattr(signal, 'pthread_sigmask'):
+            signal.pthread_sigmask(signal.SIG_BLOCK, range(1, signal.NSIG))
+        super(WebSocketClient, self).run()
 
     @property
     def daemon(self):

--- a/ws4py/client/tornadoclient.py
+++ b/ws4py/client/tornadoclient.py
@@ -84,7 +84,7 @@ class TornadoWebSocketClient(WebSocketBaseClient):
         self.io.set_close_callback(None)
         try:
             response_line, _, headers = data.partition(b'\r\n')
-            self.process_response_line(response_line)
+            self.check_response_line(response_line)
             protocols, extensions = self.process_handshake_header(headers)
         except HandshakeError:
             self.close_connection()

--- a/ws4py/client/tornadoclient.py
+++ b/ws4py/client/tornadoclient.py
@@ -7,6 +7,7 @@ from ws4py.exc import HandshakeError
 
 __all__ = ['TornadoWebSocketClient']
 
+
 class TornadoWebSocketClient(WebSocketBaseClient):
     def __init__(self, url, protocols=None, extensions=None,
                  io_loop=None, ssl_options=None, headers=None):
@@ -34,7 +35,9 @@ class TornadoWebSocketClient(WebSocketBaseClient):
         WebSocketBaseClient.__init__(self, url, protocols, extensions,
                                      ssl_options=ssl_options, headers=headers)
         if self.scheme == "wss":
-            self.sock = ssl.wrap_socket(self.sock, do_handshake_on_connect=False, **self.ssl_options)
+            self.sock = ssl.wrap_socket(
+                self.sock, do_handshake_on_connect=False, **self.ssl_options
+            )
             self._is_secure = True
             self.io = iostream.SSLIOStream(self.sock, io_loop, ssl_options=self.ssl_options)
         else:

--- a/ws4py/compat.py
+++ b/ws4py/compat.py
@@ -11,9 +11,9 @@ free to provide patches.
 Note this has been tested against 2.7 and 3.3 only but
 should hopefully work fine with other versions too.
 """
-import sys
+from sys import version_info
 
-if sys.version_info >= (3, 0):
+if version_info >= (3, 0):
     py3k = True
     from urllib.parse import urlsplit
     range = range

--- a/ws4py/exc.py
+++ b/ws4py/exc.py
@@ -5,19 +5,27 @@ __all__ = ['WebSocketException', 'FrameTooLargeException', 'ProtocolException',
            'UnsupportedFrameTypeException', 'TextFrameEncodingException',
            'StreamClosed', 'HandshakeError', 'InvalidBytesError']
 
+
 class WebSocketException(Exception): pass
+
 
 class ProtocolException(WebSocketException): pass
 
+
 class FrameTooLargeException(WebSocketException): pass
+
 
 class UnsupportedFrameTypeException(WebSocketException): pass
 
+
 class TextFrameEncodingException(WebSocketException): pass
+
 
 class InvalidBytesError(WebSocketException): pass
 
+
 class StreamClosed(Exception): pass
+
 
 class HandshakeError(WebSocketException):
     def __init__(self, msg):

--- a/ws4py/framing.py
+++ b/ws4py/framing.py
@@ -14,6 +14,7 @@ OPCODE_PONG = 0xa
 
 __all__ = ['Frame']
 
+
 class Frame(object):
     def __init__(self, opcode=None, body=b'', masking_key=None, fin=0, rsv1=0, rsv2=0, rsv3=0):
         """
@@ -107,7 +108,7 @@ class Frame(object):
             header += pack('!B', (mask_bit | 127)) + pack('!Q', length)
         else:
             raise FrameTooLargeException()
-        
+
         ## + - - - - - - - - - - - - - - - +-------------------------------+
         ## |                               |Masking-key, if MASK set to 1  |
         ## +-------------------------------+-------------------------------+

--- a/ws4py/manager.py
+++ b/ws4py/manager.py
@@ -51,6 +51,7 @@ from ws4py.compat import py3k
 
 logger = logging.getLogger('ws4py')
 
+
 class SelectPoller(object):
     def __init__(self, timeout=0.1):
         """
@@ -96,6 +97,7 @@ class SelectPoller(object):
         r, w, x = select.select(self._fds, [], [], self.timeout)
         return r
 
+
 class EPollPoller(object):
     def __init__(self, timeout=0.1):
         """
@@ -140,6 +142,7 @@ class EPollPoller(object):
             if event | select.EPOLLIN | select.EPOLLPRI:
                 yield fd
 
+
 class KQueuePoller(object):
     def __init__(self, timeout=0.1):
         """
@@ -183,6 +186,7 @@ class KQueuePoller(object):
         for fd, event in events:
             if event | select.EPOLLIN | select.EPOLLPRI:
                 yield fd
+
 
 class WebSocketManager(threading.Thread):
     def __init__(self, poller=None):
@@ -239,7 +243,7 @@ class WebSocketManager(threading.Thread):
         """
         if websocket in self:
             return
-        
+
         logger.info("Managing websocket %s" % format_addresses(websocket))
         websocket.opened()
         with self.lock:
@@ -257,7 +261,7 @@ class WebSocketManager(threading.Thread):
         """
         if websocket not in self:
             return
-        
+
         logger.info("Removing websocket %s" % format_addresses(websocket))
         with self.lock:
             fd = websocket.sock.fileno()
@@ -303,9 +307,9 @@ class WebSocketManager(threading.Thread):
             for fd in polled:
                 if not self.running:
                     break
-                
+
                 ws = self.websockets.get(fd)
-                
+
                 if ws and not ws.terminated:
                     if not ws.once():
                         with self.lock:

--- a/ws4py/messaging.py
+++ b/ws4py/messaging.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
-import os
+from os import urandom
 import struct
 
-from ws4py.framing import Frame, OPCODE_CONTINUATION, OPCODE_TEXT, \
-     OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG
+from ws4py.framing import (
+    Frame, OPCODE_CONTINUATION, OPCODE_TEXT, OPCODE_BINARY,
+    OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG
+)
 from ws4py.compat import unicode, py3k
 
 __all__ = ['Message', 'TextMessage', 'BinaryMessage', 'CloseControlMessage',
            'PingControlMessage', 'PongControlMessage']
+
 
 class Message(object):
     def __init__(self, opcode, data=b'', encoding='utf-8'):
@@ -50,7 +53,7 @@ class Message(object):
         If ``mask`` is set, automatically mask the frame
         using a generated 4-byte token.
         """
-        mask = os.urandom(4) if mask else None
+        mask = urandom(4) if mask else None
         return Frame(body=self.data, opcode=self.opcode,
                      masking_key=mask, fin=1).build()
 
@@ -66,7 +69,7 @@ class Message(object):
         """
         fin = 1 if last is True else 0
         opcode = self.opcode if first is True else OPCODE_CONTINUATION
-        mask = os.urandom(4) if mask else None
+        mask = urandom(4) if mask else None
         return Frame(body=self.data,
                      opcode=opcode, masking_key=mask,
                      fin=fin).build()
@@ -111,6 +114,7 @@ class Message(object):
     def __unicode__(self):
         return self.data.decode(self.encoding)
 
+
 class TextMessage(Message):
     def __init__(self, text=None):
         Message.__init__(self, OPCODE_TEXT, text)
@@ -122,6 +126,7 @@ class TextMessage(Message):
     @property
     def is_text(self):
         return True
+
 
 class BinaryMessage(Message):
     def __init__(self, bytes=None):
@@ -137,6 +142,7 @@ class BinaryMessage(Message):
 
     def __len__(self):
         return len(self.data)
+
 
 class CloseControlMessage(Message):
     def __init__(self, code=1000, reason=''):
@@ -160,9 +166,11 @@ class CloseControlMessage(Message):
     def __unicode__(self):
         return self.reason.decode(self.encoding)
 
+
 class PingControlMessage(Message):
     def __init__(self, data=None):
         Message.__init__(self, OPCODE_PING, data)
+
 
 class PongControlMessage(Message):
     def __init__(self, data):

--- a/ws4py/websocket.py
+++ b/ws4py/websocket.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import socket
-import ssl
 import time
 import threading
 import types

--- a/ws4py/websocket.py
+++ b/ws4py/websocket.py
@@ -12,19 +12,19 @@ try:
 except ImportError:
     class pyOpenSSLError(Exception):
         pass
-    
-from ws4py import WS_KEY, WS_VERSION
-from ws4py.exc import HandshakeError, StreamClosed
+
 from ws4py.streaming import Stream
-from ws4py.messaging import Message, PingControlMessage,\
-    PongControlMessage
-from ws4py.compat import basestring, unicode
+from ws4py.messaging import (
+    Message, PingControlMessage, PongControlMessage
+)
+from ws4py.compat import basestring
 
 DEFAULT_READING_SIZE = 2
 
 logger = logging.getLogger('ws4py')
 
 __all__ = ['WebSocket', 'EchoWebSocket', 'Heartbeat']
+
 
 class Heartbeat(threading.Thread):
     def __init__(self, websocket, frequency=2.0):
@@ -68,8 +68,11 @@ class Heartbeat(threading.Thread):
                 self.websocket.close_connection()
                 break
 
+
 class WebSocket(object):
-    """ Represents a websocket endpoint and provides a high level interface to drive the endpoint. """
+    """
+    Represents a websocket endpoint and provides a high level interface to drive the endpoint.
+    """
 
     def __init__(self, sock, protocols=None, extensions=None, environ=None, heartbeat_freq=None):
         """ The ``sock`` is an opened connection
@@ -107,12 +110,12 @@ class WebSocket(object):
         """
         Underlying connection.
         """
-        
+
         self._is_secure = hasattr(sock, '_ssl') or hasattr(sock, '_sslobj')
         """
         Tell us if the socket is secure or not.
         """
-        
+
         self.client_terminated = False
         """
         Indicates if the client has been marked as terminated.
@@ -187,7 +190,9 @@ class WebSocket(object):
         """
         if not self.server_terminated:
             self.server_terminated = True
-            self._write(self.stream.close(code=code, reason=reason).single(mask=self.stream.always_mask))
+            self._write(
+                self.stream.close(code=code, reason=reason).single(mask=self.stream.always_mask)
+            )
 
     def closed(self, code, reason=None):
         """
@@ -254,7 +259,7 @@ class WebSocket(object):
         """
         Called whenever a socket, or an OS, error is trapped
         by ws4py but not managed by it. The given error is
-        an instance of `socket.error` or `OSError`. 
+        an instance of `socket.error` or `OSError`.
 
         Note however that application exceptions will not go
         through this handler. Instead, do make sure you
@@ -301,11 +306,13 @@ class WebSocket(object):
             data = payload.single(mask=self.stream.always_mask)
             self._write(data)
 
-        elif type(payload) == types.GeneratorType:
+        elif isinstance(payload, types.GeneratorType):
             bytes = next(payload)
             first = True
             for chunk in payload:
-                self._write(message_sender(bytes).fragment(first=first, mask=self.stream.always_mask))
+                self._write(
+                    message_sender(bytes).fragment(first=first, mask=self.stream.always_mask)
+                )
                 bytes = chunk
                 first = False
 
@@ -320,14 +327,14 @@ class WebSocket(object):
         as the socket interface but behaves differently.
 
         When data is sent over a SSL connection
-        more data may be read than was requested from by 
+        more data may be read than was requested from by
         the ws4py websocket object.
 
-        In that case, the data may have been indeed read 
-        from the underlying real socket, but not read by the 
-        application which will expect another trigger from the 
+        In that case, the data may have been indeed read
+        from the underlying real socket, but not read by the
+        application which will expect another trigger from the
         manager's polling mechanism as if more data was still on the
-        wire. This will happen only when new data is 
+        wire. This will happen only when new data is
         sent by the other peer which means there will be
         some delay before the initial read data is handled
         by the application.
@@ -336,7 +343,7 @@ class WebSocket(object):
         to query the internal SSL socket buffer if it has indeed
         more data pending in its buffer.
 
-        Now, some people in the Python community 
+        Now, some people in the Python community
         `discourage <https://bugs.python.org/issue21430>`_
         this usage of the ``pending()`` method because it's not
         the right way of dealing with such use case. They advise
@@ -345,10 +352,11 @@ class WebSocket(object):
         application can directly control the poller which is not
         the case with the WebSocket abstraction here.
 
-        We therefore rely on this `technic <http://stackoverflow.com/questions/3187565/select-and-ssl-in-python>`_
+        We therefore rely on this
+        `technic <http://stackoverflow.com/questions/3187565/select-and-ssl-in-python>`_
         which seems to be valid anyway.
 
-        This is a bit of a shame because we have to process 
+        This is a bit of a shame because we have to process
         more data than what wanted initially.
         """
         data = b""
@@ -357,7 +365,7 @@ class WebSocket(object):
             data += self.sock.recv(pending)
             pending = self.sock.pending()
         return data
-        
+
     def once(self):
         """
         Performs the operation of reading from the underlying
@@ -444,7 +452,7 @@ class WebSocket(object):
 
         if not bytes and self.reading_buffer_size > 0:
             return False
-        
+
         self.reading_buffer_size = s.parser.send(bytes) or DEFAULT_READING_SIZE
 
         if s.closing is not None:
@@ -515,6 +523,7 @@ class WebSocket(object):
                         break
             finally:
                 self.terminate()
+
 
 class EchoWebSocket(WebSocket):
     def received_message(self, message):


### PR DESCRIPTION
This helps to not terminate the websocket on a 'C^' or a general system interrupt.

This is basically a lower down in the implementation version of #151 since I did it in websocket.py (as I am not using manager)
