### PR TITLE
Give application status code 1005 when no good status code is parsed/received

### DIFF
--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -148,7 +148,7 @@ class WSStreamTest(unittest.TestCase):
         self.assertEqual(s.closing, None)
         s.parser.send(f)
         self.assertEqual(type(s.closing), CloseControlMessage)
-        self.assertEqual(s.closing.code, 1002)
+        self.assertEqual(s.closing.code, 1005)
 
     def test_close_message_of_size_one_are_invalid(self):
         payload = b'*'
@@ -159,7 +159,7 @@ class WSStreamTest(unittest.TestCase):
         self.assertEqual(s.closing, None)
         s.parser.send(f)
         self.assertEqual(type(s.closing), CloseControlMessage)
-        self.assertEqual(s.closing.code, 1002)
+        self.assertEqual(s.closing.code, 1005)
 
     def test_invalid_close_message_type(self):
         payload = struct.pack("!H", 1500) + b'hello'
@@ -170,7 +170,7 @@ class WSStreamTest(unittest.TestCase):
         self.assertEqual(s.closing, None)
         s.parser.send(f)
         self.assertEqual(type(s.closing), CloseControlMessage)
-        self.assertEqual(s.closing.code, 1002)
+        self.assertEqual(s.closing.code, 1005)
 
     def test_invalid_close_message_reason_encoding(self):
         payload = struct.pack("!H", 1000) + b'h\xc3llo'

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -18,6 +18,7 @@ class WSStreamTest(unittest.TestCase):
         self.assertEqual(s.closing, None)
         s.parser.send(f)
         self.assertEqual(type(s.closing), CloseControlMessage)
+        self.assertEqual(s.closing.code, 1005)
 
     def test_missing_masking_key_when_expected(self):
         f = Frame(opcode=OPCODE_TEXT, body=b'hello', fin=1, masking_key=None).build()

--- a/ws4py/streaming.py
+++ b/ws4py/streaming.py
@@ -259,25 +259,24 @@ class Stream(object):
                                     break
 
                     elif frame.opcode == OPCODE_CLOSE:
-                        code = 1000
+                        code = 1005
                         reason = ""
                         if frame.payload_length == 0:
-                            self.closing = CloseControlMessage(code=1000)
+                            self.closing = CloseControlMessage(code=1005)
                         elif frame.payload_length == 1:
-                            self.closing = CloseControlMessage(code=1002, reason='Payload has invalid length')
+                            self.closing = CloseControlMessage(code=1005, reason='Payload has invalid length')
                         else:
                             try:
                                 # at this stage, some_bytes have been unmasked
                                 # so actually are held in a bytearray
                                 code = int(unpack("!H", bytes(some_bytes[0:2]))[0])
                             except struct.error:
-                                code = 1002
                                 reason = 'Failed at decoding closing code'
                             else:
                                 # Those codes are reserved or plainly forbidden
                                 if code not in VALID_CLOSING_CODES and not (2999 < code < 5000):
                                     reason = 'Invalid Closing Frame Code: %d' % code
-                                    code = 1002
+                                    code = 1005
                                 elif frame.payload_length > 1:
                                     reason = some_bytes[2:] if frame.masking_key else frame.body[2:]
 

--- a/ws4py/websocket.py
+++ b/ws4py/websocket.py
@@ -166,7 +166,7 @@ class WebSocket(object):
     def opened(self):
         """
         Called by the server when the upgrade handshake
-        has succeeeded.
+        has succeeded.
         """
         pass
 


### PR DESCRIPTION
1005 is "designated for use in applications expecting a status code
to indicate that no status code was actually present."

1002 is for telling the other endpoint that there was a protocol
error. Giving the application 1002 on a parse error is misleading,
as it's indistinguishable from the far endpoint complaining about something
you sent being invalid.
