### PR TITLE
Eliminate a protocol error when first chunk is last too.

### DIFF
--- a/ws4py/websocket.py
+++ b/ws4py/websocket.py
@@ -308,7 +308,7 @@ class WebSocket(object):
                 bytes = chunk
                 first = False
 
-            self._write(message_sender(bytes).fragment(last=True, mask=self.stream.always_mask))
+            self._write(message_sender(bytes).fragment(first=first, last=True, mask=self.stream.always_mask))
 
         else:
             raise ValueError("Unsupported type '%s' passed to send()" % type(payload))


### PR DESCRIPTION
Cowboy server rejects the connection when chunk is last too. It is due to the fact that the frame bits are like **FIN=0x1 and OPCODE=0x0 and there is no more data to send.
