### PR TITLE
Block on receiving from SSL socket

### DIFF
--- a/ws4py/websocket.py
+++ b/ws4py/websocket.py
@@ -387,10 +387,9 @@ class WebSocket(object):
             logger.debug("WebSocket is already terminated")
             return False
         try:
+            b = self.sock.recv(self.reading_buffer_size)
             if self._is_secure:
-                b = self._get_from_pending()
-            else:
-                b = self.sock.recv(self.reading_buffer_size)
+                b += self._get_from_pending()
             if not b:
                 return False
             self.buf += b


### PR DESCRIPTION
This fixes a bug where not receiving any bytes immediately from an SSL socket would be considered a socket error and the connection would be closed. This changes the code to block and wait for bytes from the SSL socket.

To test, I used the example DummyClient script in the [tutorial](https://ws4py.readthedocs.io/en/latest/sources/clienttutorial/#built-in) and pointed it to "wss://echo.websocket.org". Without this change, the example script closes the connection without receiving any messages. With the change, the expected behavior occurs.