### PR TITLE
Create MANIFEST.in with LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+include CHANGELOG.md


### PR DESCRIPTION
Hey-lo,

I'm maintaining a version of `ws4py` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). (See [here](https://github.com/conda-forge/ws4py-feedstock/).) When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

This pull should add just such a manifest, guaranteeing that the license, the change log, and the readme are included in future source distributions.