### PR TITLE
Adds argument to set block value on gevent get command in WebSocketClient.receive()

### DIFF
--- a/ws4py/client/geventclient.py
+++ b/ws4py/client/geventclient.py
@@ -75,18 +75,22 @@ class WebSocketClient(WebSocketBaseClient):
         # to wait for
         self.messages.put(StopIteration)
 
-    def receive(self):
+    def receive(self, block=True):
         """
         Returns messages that were stored into the
         `messages` queue and returns `None` when the
         websocket is terminated or closed.
+        `block` is passed though the gevent queue `.get()` method, which if 
+        True will block until an item in the queue is available. Set this to 
+        False if you just want to check the queue, which will raise an 
+        Empty exception you need to handle if there is no message to return.
         """
         # If the websocket was terminated and there are no messages
         # left in the queue, return None immediately otherwise the client
         # will block forever
         if self.terminated and self.messages.empty():
             return None
-        message = self.messages.get()
+        message = self.messages.get(block=block)
         if message is StopIteration:
             return None
         return message


### PR DESCRIPTION
I'm using the gevent websocket client to manage some web socket connections for a load testing project.
As part of this I need to constantly poll the websocket checking to see if messages have been received that my tests need to act on, it can't wait for a message to be received as this then blocks other actions the tests need to perform.

As the gevent queue `.get()` method lets you specify if you want to get command to be blocking or not, I've added this as a pass through for the `WebSocketClient.receive()` method. 
I've defaulted it to True, as thats the `.get()` default, so it will keep current behaviour the same unless explicitly specified otherwise. 

I've added a note to the doc string about handling the `Empty` error raised if there are no messages in the queue, but I can raise a further PR for documentation if you think it needs explaining in more detail. 
