### PR TITLE
Fix for #226.

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -94,10 +94,11 @@ class WebSocketBaseClient(WebSocket):
             # Let's handle IPv4 and IPv6 addresses
             # Simplified from CherryPy's code
             try:
-                family, socktype, proto, canonname, sa = socket.getaddrinfo(self.host, self.port,
-                                                                            socket.AF_UNSPEC,
-                                                                            socket.SOCK_STREAM,
-                                                                            0, socket.AI_PASSIVE)[0]
+                addrinfo = socket.getaddrinfo(self.host, self.port,
+                                              socket.AF_UNSPEC,
+                                              socket.SOCK_STREAM,
+                                              0, socket.AI_PASSIVE)
+                    
             except socket.gaierror:
                 family = socket.AF_INET
                 if self.host.startswith('::'):
@@ -107,16 +108,34 @@ class WebSocketBaseClient(WebSocket):
                 proto = 0
                 canonname = ""
                 sa = (self.host, self.port, 0, 0)
+                
+                addrinfo = [(2, 1, 0, '', ('localhost', 9000, 0, 0))]
+                
+            for family, socktype, proto, canonname, sa in addrinfo:
 
-            sock = socket.socket(family, socktype, proto)
-            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            if hasattr(socket, 'AF_INET6') and family == socket.AF_INET6 and \
-              self.host.startswith('::'):
+                sock = socket.socket(family, socktype, proto)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                if hasattr(socket, 'AF_INET6') and family == socket.AF_INET6 and \
+                  self.host.startswith('::'):
+                    try:
+                        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                    except (AttributeError, socket.error):
+                        pass
+                    
+                if self.scheme == "wss":
+                    # default port is now 443; upgrade self.sender to send ssl
+                    sock = ssl.wrap_socket(self.sock, **self.ssl_options)
+                    self._is_secure = True
+                
                 try:
-                    sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-                except (AttributeError, socket.error):
-                    pass
+                    sock.connect(self.bind_addr)
+                except socket.error as err:
+                    sock = None
+                    continue
+                
+        if sock is None:
+            raise err
 
         WebSocket.__init__(self, sock, protocols=protocols,
                            extensions=extensions,
@@ -206,15 +225,9 @@ class WebSocketBaseClient(WebSocket):
 
     def connect(self):
         """
-        Connects this websocket and starts the upgrade handshake
+        Starts the upgrade handshake
         with the remote endpoint.
         """
-        if self.scheme == "wss":
-            # default port is now 443; upgrade self.sender to send ssl
-            self.sock = ssl.wrap_socket(self.sock, **self.ssl_options)
-            self._is_secure = True
-
-        self.sock.connect(self.bind_addr)
 
         self._write(self.handshake_request)
 


### PR DESCRIPTION
Currently the client init uses only the first address info tuple returned from `socket.getaddrinfo()` to create the socket (see line [97](https://github.com/Lawouach/WebSocket-for-Python/compare/master...emmawillemsma:getaddrinfo_fix?expand=1#diff-4e1ced24fcdbed07138d01da11e174ecL97)). Unfortunately sometimes this isn't the right address. Best practice is to iterate through the address info tuples until we find one that we can connect to successfully. See [this stack overflow question](https://stackoverflow.com/questions/11572843/is-it-necessary-to-attempt-to-connect-to-all-addresses-returned-by-getaddrinfo). This change necessitated moving the call to `socket.connect` out of the `WebSocketBaseClient.connect` method and into the `WebSocketBaseClient.init` method. If that is not desirable, we could instead pass the list of address information into the `connect` method and let the initialization of the socket happen there.