### PR TITLE
Remove SO_REUSEADDR

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -110,7 +110,6 @@ class WebSocketBaseClient(WebSocket):
 
             sock = socket.socket(family, socktype, proto)
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             if hasattr(socket, 'AF_INET6') and family == socket.AF_INET6 and \
               self.host.startswith('::'):
                 try:


### PR DESCRIPTION
Reusing address for ephemeral ports is not a good idea and may cause
"Address already in use" error.
See https://gavv.github.io/blog/ephemeral-port-reuse/ for a more
detailed explanation.