### PR TITLE
Travis CI: Upgrade to Python 3.7 and add flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ group: travis_latest
 
 language: python
 
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+
 matrix:
   include:
-    - python: 2.7
-    - python: 3.4
-    - python: 3.5
-    - python: 3.6
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  # exit-zero treats all errors as warnings.
   - flake8 . --count --exit-zero --max-complexity=10 --statistics
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - flake8 . --count --exit-zero --max-complexity=10 --statistics
 
 script: 
-  - py.test -v
+  - pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
+group: travis_latest
+
 language: python
 
-python:
-  - 2.7
-  - 3.3
-  - 3.5
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 before_install:
   - sudo apt-get install python-dev libevent-dev
@@ -12,8 +19,14 @@ before_install:
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install -r requirements/py2kreqs.txt; fi 
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install -r requirements/py3kreqs.txt; fi
+  - pip install flake8
   - python setup.py install
 
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 script: 
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then py.test -v; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then py.test -v; fi
+  - py.test -v

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27
+envlist = py{27,37}
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
* Add Python 3.7 to Travis CI and tox in alignment with travis-ci/travis-ci#9069
* Add [flake8](http://flake8.pycqa.org) tests to look for Python syntax errors and undefined names

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree