### PR TITLE
Fix Incorrect 'Sec-WebSocket-Accept' header value

### DIFF
--- a/ws4py/server/cherrypyserver.py
+++ b/ws4py/server/cherrypyserver.py
@@ -186,6 +186,9 @@ class WebSocketTool(Tool):
             location.append("?%s" % request.query_string)
         ws_location = ''.join(location)
 
+        accept_value = base64.b64encode(sha1(key.encode('utf-8') + WS_KEY).digest())
+        if py3k: accept_value = accept_value.decode('utf-8')
+
         response = cherrypy.serving.response
         response.stream = True
         response.status = '101 Switching Protocols'
@@ -193,7 +196,7 @@ class WebSocketTool(Tool):
         response.headers['Upgrade'] = 'websocket'
         response.headers['Connection'] = 'Upgrade'
         response.headers['Sec-WebSocket-Version'] = str(version)
-        response.headers['Sec-WebSocket-Accept'] = base64.b64encode(sha1(key.encode('utf-8') + WS_KEY).digest())
+        response.headers['Sec-WebSocket-Accept'] = accept_value
         if ws_protocols:
             response.headers['Sec-WebSocket-Protocol'] = ', '.join(ws_protocols)
         if ws_extensions:


### PR DESCRIPTION
For cherrypyserver on Python 3 and above (tested with Python 3.6)
Same logic applied as in wsgiutils.py

Screenshot of issue:
![image](https://user-images.githubusercontent.com/1945295/47589479-891d6a80-d969-11e8-970c-1e1432bfcf99.png)

As you can see, the value of the 'Sec-Websocket-Accept' header is in the wrong format. It must be decoded when running Py3.