### PR TITLE
fix #254 (Exclude installation of tronado-5.x)

### DIFF
--- a/requirements/py3kreqs.txt
+++ b/requirements/py3kreqs.txt
@@ -1,5 +1,5 @@
 CherryPy>=5.5.0
-tornado>=4.2.3
+tornado>=4.2.3,<5.0.0
 mock>=2.0.0
 asyncio>=3.4.3
 Cython>=0.22.1


### PR DESCRIPTION
I wrote patch fix to Travel CI test fail.
Please merge this patch.

This failed Travel CI test was installed tornado-5 series.

But tornado-5 series is not support python3.3.

The Travel CI test should use tornado-4 series in python3.3.