### PR TITLE
use build_py from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-from distutils.command.build_py import build_py
+try:
+    from setuptools.command.build_py import build_py
+except ImportError:
+    from distutils.command.build_py import build_py
 
 class buildfor2or3(build_py):
     def find_package_modules(self, package, package_dir):


### PR DESCRIPTION
Fixes install error on setuptools 58.5.0-58.5.2

```shell
python -m venv /tmp/testvenv && source /tmp/testvenv/bin/activate && 
  pip install --no-cache -U pip setuptools wheel && pip install --no-cache ws4py==0.5.1
```

<details>
<summary>Error logs</summary>

```
yhlee@yhlee-mbp:/tmp$ python -V
Python 3.8.12
yhlee@yhlee-mbp:/tmp$ python -m venv /tmp/testvenv && source /tmp/testvenv/bin/activate && pip install --no-cache -U pip setuptools wheel && pip install --no-cache ws4py==0.5.1
Requirement already satisfied: pip in ./testvenv/lib/python3.8/site-packages (21.1.1)
Collecting pip
  Downloading pip-21.3.1-py3-none-any.whl (1.7 MB)
     |████████████████████████████████| 1.7 MB 4.0 MB/s 
Requirement already satisfied: setuptools in ./testvenv/lib/python3.8/site-packages (56.0.0)
Collecting setuptools
  Downloading setuptools-58.5.2-py3-none-any.whl (946 kB)
     |████████████████████████████████| 946 kB 12.6 MB/s 
Collecting wheel
  Downloading wheel-0.37.0-py2.py3-none-any.whl (35 kB)
Installing collected packages: wheel, setuptools, pip
  Attempting uninstall: setuptools
    Found existing installation: setuptools 56.0.0
    Uninstalling setuptools-56.0.0:
      Successfully uninstalled setuptools-56.0.0
  Attempting uninstall: pip
    Found existing installation: pip 21.1.1
    Uninstalling pip-21.1.1:
      Successfully uninstalled pip-21.1.1
Successfully installed pip-21.3.1 setuptools-58.5.2 wheel-0.37.0
Collecting ws4py==0.5.1
  Downloading ws4py-0.5.1.tar.gz (51 kB)
     |████████████████████████████████| 51 kB 2.5 MB/s            
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /tmp/testvenv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-install-b6sdpikr/ws4py_e36c74e13772460bab6343418581baea/setup.py'"'"'; __file__='"'"'/private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-install-b6sdpikr/ws4py_e36c74e13772460bab6343418581baea/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-pip-egg-info-krc4wx4w
       cwd: /private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-install-b6sdpikr/ws4py_e36c74e13772460bab6343418581baea/
  Complete output (35 lines):
  running egg_info
  creating /private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-pip-egg-info-krc4wx4w/ws4py.egg-info
  writing /private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-pip-egg-info-krc4wx4w/ws4py.egg-info/PKG-INFO
  writing dependency_links to /private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-pip-egg-info-krc4wx4w/ws4py.egg-info/dependency_links.txt
  writing top-level names to /private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-pip-egg-info-krc4wx4w/ws4py.egg-info/top_level.txt
  writing manifest file '/private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-pip-egg-info-krc4wx4w/ws4py.egg-info/SOURCES.txt'
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/8c/rsppgx390x57zffhvy_l3xb00000gp/T/pip-install-b6sdpikr/ws4py_e36c74e13772460bab6343418581baea/setup.py", line 40, in <module>
      setup(name = "ws4py",
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/__init__.py", line 159, in setup
      return distutils.core.setup(**attrs)
    File "/Users/yhlee/.pyenv/versions/3.8.12/lib/python3.8/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/Users/yhlee/.pyenv/versions/3.8.12/lib/python3.8/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/Users/yhlee/.pyenv/versions/3.8.12/lib/python3.8/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 299, in run
      self.find_sources()
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 306, in find_sources
      mm.run()
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 541, in run
      self.add_defaults()
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
      sdist.add_defaults(self)
    File "/Users/yhlee/.pyenv/versions/3.8.12/lib/python3.8/distutils/command/sdist.py", line 226, in add_defaults
      self._add_defaults_python()
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/command/sdist.py", line 113, in _add_defaults_python
      self._add_data_files(self._safe_data_files(build_py))
    File "/tmp/testvenv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 621, in _safe_data_files
      return build_py.get_data_files_without_manifest()
    File "/Users/yhlee/.pyenv/versions/3.8.12/lib/python3.8/distutils/cmd.py", line 103, in __getattr__
      raise AttributeError(attr)
  AttributeError: get_data_files_without_manifest
  ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/53/20/4019a739b2eefe9282d3822ef6a225250af964b117356971bd55e274193c/ws4py-0.5.1.tar.gz#sha256=29d073d7f2e006373e6a848b1d00951a1107eb81f3742952be905429dc5a5483 (from https://pypi.org/simple/ws4py/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement ws4py==0.5.1 (from versions: 0.3.2, 0.3.4, 0.3.5, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.5.0, 0.5.1)
ERROR: No matching distribution found for ws4py==0.5.1
(testvenv) yhlee@yhlee-mbp:/tmp:1$ 
```
</details>

https://github.com/pypa/setuptools/issues/2849