### PR TITLE
Fix ssl deprecate warn

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -212,7 +212,7 @@ class WebSocketBaseClient(WebSocket):
             # Prevent check_hostname requires server_hostname (ref #187)
             if "cert_reqs" not in self.ssl_options:
                 context.check_hostname = False
-                context.verify_mode = ssl.CERT_NONE
+                context.verify_mode = ssl.CERT_NONE 
 
             self.sock = context.wrap_socket(self.sock)
             self._is_secure = True

--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -81,11 +81,6 @@ class WebSocketBaseClient(WebSocket):
         self.exclude_headers = exclude_headers or []
         self.exclude_headers = [x.lower() for x in self.exclude_headers]
 
-        if self.scheme == "wss":
-            # Prevent check_hostname requires server_hostname (ref #187)
-            if "cert_reqs" not in self.ssl_options:
-                self.ssl_options["cert_reqs"] = ssl.CERT_NONE
-
         self._parse_url()
 
         if self.unix_socket_path:
@@ -211,7 +206,14 @@ class WebSocketBaseClient(WebSocket):
         """
         if self.scheme == "wss":
             # default port is now 443; upgrade self.sender to send ssl
-            self.sock = ssl.wrap_socket(self.sock, **self.ssl_options)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            if self.ssl_options.get('certfile', None):
+                context.load_cert_chain(self.ssl_options.get('certfile'), self.ssl_options.get('keyfile'))
+            # Prevent check_hostname requires server_hostname (ref #187)
+            if "cert_reqs" not in self.ssl_options:
+                context.check_hostname = False         
+
+            self.sock = context.wrap_socket(self.sock)
             self._is_secure = True
 
         self.sock.connect(self.bind_addr)

--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -211,7 +211,8 @@ class WebSocketBaseClient(WebSocket):
                 context.load_cert_chain(self.ssl_options.get('certfile'), self.ssl_options.get('keyfile'))
             # Prevent check_hostname requires server_hostname (ref #187)
             if "cert_reqs" not in self.ssl_options:
-                context.check_hostname = False         
+                context.check_hostname = False
+                context.verify_mode = ssl.CERT_NONE
 
             self.sock = context.wrap_socket(self.sock)
             self._is_secure = True


### PR DESCRIPTION
ssl.wrap_socket() is deprecated from python 3.7 (see https://docs.python.org/3/library/ssl.html#ssl.SSLSocket). Based on documentation SSLContext.wrap_socket() should be used instead.
