### PR TITLE
Added tls support for validating certificates

### DIFF
--- a/ws4py/client/__init__.py
+++ b/ws4py/client/__init__.py
@@ -206,15 +206,20 @@ class WebSocketBaseClient(WebSocket):
         """
         if self.scheme == "wss":
             # default port is now 443; upgrade self.sender to send ssl
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            protocol = getattr(ssl, 'PROTOCOL_TLS_CLIENT', ssl.PROTOCOL_TLSv1_2)  # PROTOCOL_TLS_CLIENT is correct for newer Python but doesn't exist on older Pythons
+            context = ssl.SSLContext(protocol)
             if self.ssl_options.get('certfile', None):
                 context.load_cert_chain(self.ssl_options.get('certfile'), self.ssl_options.get('keyfile'))
+
+            if self.ssl_options.get('ca_certs'):
+                context.load_verify_locations(self.ssl_options['ca_certs'])
+
             # Prevent check_hostname requires server_hostname (ref #187)
             if "cert_reqs" not in self.ssl_options:
                 context.check_hostname = False
                 context.verify_mode = ssl.CERT_NONE
 
-            self.sock = context.wrap_socket(self.sock)
+            self.sock = context.wrap_socket(self.sock, server_hostname=self.host)
             self._is_secure = True
 
         self.sock.connect(self.bind_addr)


### PR DESCRIPTION
The implementation made several months ago at https://github.com/Lawouach/WebSocket-for-Python/commit/9ffee997a128ea9d7b09fb1dcf4aa280d25ebdc9 works properly when turning on wss:// URLs but fails when trying to turn on server cert validation.

This fixes the issues with cert validation - I made this change on my day job's internal Gitlab, and I'm making a PR back into the public repo to contribute the fix back.