### PR TITLE
fix: run_forever() now waits for thread completion before returning (closes #152)

### DIFF
--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -55,8 +55,7 @@ class WebSocketClient(WebSocketBaseClient):
         Simply blocks the thread until the
         websocket has terminated.
         """
-        while not self.terminated:
-            self._th.join(timeout=0.1)
+        self._th.join()
 
     def handshake_ok(self):
         """


### PR DESCRIPTION
## What
`run_forever()` was polling `self.terminated` in a loop and could return before the websocket's `closed()` method had finished executing. This is because `client_terminated` and `server_terminated` are set to `True` in `websocket.py` before `closed()` is called, so `self.terminated` returns `True` prematurely.

## Fix
Instead of polling `self.terminated`, `run_forever()` now simply calls `self._th.join()` which blocks until the worker thread has fully completed — including after `closed()` returns. This is simpler, more correct, and avoids the race condition entirely.

Closes #152