### PR TITLE
fix: reduce CPU spin in run_forever by increasing join timeout (closes #142)

### DIFF
--- a/ws4py/client/threadedclient.py
+++ b/ws4py/client/threadedclient.py
@@ -54,9 +54,19 @@ class WebSocketClient(WebSocketBaseClient):
         """
         Simply blocks the thread until the
         websocket has terminated.
+
+        .. note::
+
+           Signals and threads do not always play well together in Python.
+           Without a timeout, this method cannot be interrupted by a
+           SIGINT (KeyboardInterrupt). The timeout ensures we return to
+           the main thread periodically so pending signals can be
+           processed. A longer timeout reduces CPU usage in idle
+           processes at the cost of slightly slower signal response.
+           Override this method if you need different behaviour.
         """
         while not self.terminated:
-            self._th.join(timeout=0.1)
+            self._th.join(timeout=5.0)
 
     def handshake_ok(self):
         """


### PR DESCRIPTION
## What

The `run_forever()` method in `threadedclient.py` uses `self._th.join(timeout=0.1)` in a loop. This causes the main thread to wake up 10 times per second even when the WebSocket is idle, leading to noticeable CPU usage and fan spin-up in applications with many standby connections.

The short timeout was originally introduced (see #109) to allow SIGINT (KeyboardInterrupt) to interrupt the blocking join call, since Python signal handlers only run in the main thread between bytecode instructions.

## Fix

- Increase the join timeout from `0.1` to `5.0` seconds, reducing CPU wake-ups from 10/s to 0.2/s while still allowing SIGINT to be handled within a reasonable time.
- Add a docstring note explaining the reason for the timeout so future developers understand the tradeoff.

Closes #142